### PR TITLE
fix(snapshot): improve snapshot container

### DIFF
--- a/Dockerfiles/Dockerfile.snapshot
+++ b/Dockerfiles/Dockerfile.snapshot
@@ -7,9 +7,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN yarn install --frozen-lockfile --network-timeout 1000000
-
-RUN yarn run build
+RUN yarn install --network-timeout 1000000
 
 ENV PORT=3000
 EXPOSE 3000


### PR DESCRIPTION
Removed `yarn run build` since it only makes the volume bigger, but we don't use it