### PR TITLE
fix(snapshot): add node-gyp to global dependencies

### DIFF
--- a/Dockerfiles/Dockerfile.snapshot
+++ b/Dockerfiles/Dockerfile.snapshot
@@ -1,8 +1,9 @@
 FROM node:18-alpine
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache git py3-pip python3 gcc g++ make
-
+    apk add --no-cache git py3-pip python3 gcc g++ make && \
+    npm install -g node-gyp
+    
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
Add node-gyp to global dependencies. It fixes the problem with installing dependencies in snapshot container